### PR TITLE
Specify that time option takes upto 2 args.

### DIFF
--- a/src/main/java/be/ugent/intec/gtfsfilter/Main.java
+++ b/src/main/java/be/ugent/intec/gtfsfilter/Main.java
@@ -228,8 +228,7 @@ public class Main {
 		OptionBuilder.withArgName("start:end");
 		OptionBuilder.withLongOpt("timespan");
 		OptionBuilder.withDescription(DESCRIPTION_OPT_TIME);
-		OptionBuilder.hasArgs(1);
-		OptionBuilder.hasOptionalArgs(1);
+		OptionBuilder.hasArgs(2);
 		OptionBuilder.withValueSeparator(':');
 		Option timespanOption = OptionBuilder.create(TIME_OPTION);
 


### PR DESCRIPTION
The `-d` with multi args used to be translated to single arg. E.g. given `-d 2015-08-10:2015-10-10` it would use `Applying time filter for one day: ServiceIdDate(2015-8-10)`.

Now it works as expected:
- `-d 2015-08-24:2015-08-31` - `Applying time filter for timespan: ServiceIdDate(2015-8-24) --> ServiceIdDate(2015-8-31)`
- `-d 2015-08-24` - `Applying time filter for one day: ServiceIdDate(2015-8-24)`
